### PR TITLE
Fix the logger

### DIFF
--- a/src/test/java/com/example/testcontainersbuildpacksexamples/BuildpackTest.java
+++ b/src/test/java/com/example/testcontainersbuildpacksexamples/BuildpackTest.java
@@ -29,6 +29,7 @@ public class BuildpackTest {
                 .withFinalImage("test-spring-app")
                 .withEnvironment(Map.of("BP_JVM_VERSION", "17.*"))
                 .withLogLevel("info")
+                .withNewSlf4jLogger("buildpack")
                 .build();
 
         try (GenericContainer<?> app = new GenericContainer<>("test-spring-app")
@@ -52,6 +53,7 @@ public class BuildpackTest {
                         entry("BP_NATIVE_IMAGE", "true"),
                         entry("BP_MAVEN_BUILD_ARGUMENTS", "-Pnative -Dmaven.test.skip=true --no-transfer-progress package")))
                 .withLogLevel("info")
+                .withNewSlf4jLogger("buildpack")
                 .build();
 
         try (GenericContainer<?> app = new GenericContainer<>("test-native-spring-app")


### PR DESCRIPTION
It looks like the original project has an issue with logger not being set correctly: https://github.com/snowdrop/java-buildpack-client/pull/51

But, even if they fix it, it is nice to be able to use the Slf4j one.